### PR TITLE
Dennis dittmann patch 2

### DIFF
--- a/src/AbstractShopGateway.php
+++ b/src/AbstractShopGateway.php
@@ -241,4 +241,14 @@ abstract class AbstractShopGateway extends AbstractGateway
     {
         return $this->getParameter('clearingtype');
     }
+
+    public function setWalletType($value)
+    {
+        return $this->setParameter('wallettype', $value);
+    }
+
+    public function getWalletType()
+    {
+        return $this->getParameter('wallettype');
+    }
 }

--- a/src/Message/ShopFrontendAuthorizeRequest.php
+++ b/src/Message/ShopFrontendAuthorizeRequest.php
@@ -60,6 +60,7 @@ class ShopFrontendAuthorizeRequest extends ShopServerAuthorizeRequest
                 : AbstractShopGateway::MODE_LIVE,
             'request' => $this->getRequestCode(),
             'clearingtype' => $this->getClearingType(),
+            'wallettype' => $this->getWalletType(),
             'reference' => $this->getTransactionId(),
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrency(),


### PR DESCRIPTION
added getter and setter for wallettype

if parameter 'clearingtype' equals 'wlt' (e-wallet), the wallettype (PayPal, Paydirekt, ...) must be transfered to PAYONE, too