### PR TITLE
ECS-203695 Verifizierungs-Umleitung für Kreditkarten-Belastung verhindern

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -436,13 +436,13 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
             $expiryYear = $card->getExpiryYear();
             $expiryMonth = $card->getExpiryMonth();
 
+            if ($this->getEcommerceMode()) {
+                $data['ecommercemode'] = $this->getEcommerceMode();
+            }
+
             if (empty($expiryYear) && empty($expiryMonth) && $card->getCvv() === null) {
                 $data['pseudocardpan'] = $card->getNumber();
             } elseif ($card->getNumber()) {
-                if ($this->getEcommerceMode()) {
-                    $data['ecommercemode'] = $this->getEcommerceMode();
-                }
-
                 $data['cardpan'] = $card->getNumber();
 
                 $data['cardtype'] = $this->getCardType();


### PR DESCRIPTION
Makes it possible to use the parameter `ecommercemode` for pseudo credit card PANs.